### PR TITLE
fix: Log request payload

### DIFF
--- a/demo/istio/manifests/ext-authz.yaml
+++ b/demo/istio/manifests/ext-authz.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ext-authz
+  labels:
+    app: ext-authz
+  namespace: demo  
+spec:
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8000
+  - name: grpc
+    port: 9000
+    targetPort: 9000
+  selector:
+    app: ext-authz
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ext-authz
+  namespace: demo 
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ext-authz 
+  template:
+    metadata:
+      labels:
+        app: ext-authz
+    spec:
+      containers:
+      - image: ko.local/github.com/kyverno/kyverno-envoy-plugin:7bd39c9d958eb408a86cee2d97241895522b317f
+        imagePullPolicy: IfNotPresent
+        name: ext-authz
+        ports:
+        - containerPort: 8000
+        - containerPort: 9000

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,20 @@ module github.com/kyverno/kyverno-envoy-plugin
 go 1.21.4
 
 require (
+	github.com/envoyproxy/go-control-plane v0.12.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80
 	google.golang.org/grpc v1.62.1
 	k8s.io/apimachinery v0.29.2
 )
 
 require (
+	github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa // indirect
+	github.com/envoyproxy/protoc-gen-validate v1.0.4 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80 // indirect
 	google.golang.org/protobuf v1.32.0 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa h1:jQCWAUqqlij9Pgj2i/PB79y4KOPYVyFYdROxgaCwdTQ=
+github.com/cncf/xds/go v0.0.0-20231128003011-0fa0005c9caa/go.mod h1:x/1Gn8zydmfq8dk6e9PdstVsDgu9RuyIIJqAaF//0IM=
+github.com/envoyproxy/go-control-plane v0.12.0 h1:4X+VP1GHd1Mhj6IB5mMeGbLCleqxjletLK6K0rbxyZI=
+github.com/envoyproxy/go-control-plane v0.12.0/go.mod h1:ZBTaoJ23lqITozF0M6G4/IragXCQKCnYbmlmtHvwRG0=
+github.com/envoyproxy/protoc-gen-validate v1.0.4 h1:gVPz/FMfvh57HdSJQyvBtF00j8JU4zdyUgIUNhlgg0A=
+github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
 github.com/go-logr/logr v1.3.0 h1:2y3SDp0ZXuc6/cjLSZ+Q3ir+QB9T/iG5yYRXqsagWSY=
 github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=


### PR DESCRIPTION
when i executed with command `curl -X POST -d '{"key": "value"}' -H "Content-Type: application/json" http://127.0.0.1:8000`
The result where 
```console
sanskar@sanskar-HP-Laptop-15s-du1xxx:~/kyverno-envoy-plugin$ go run main.go 
Starting HTTP server on Port 8000
Starting GRPC server on Port 9000
Received request from 127.0.0.1:51952 /
Request payload: {"key": "value"}
```

Test with istio demo 
Request -
```console
sanskar@sanskar-HP-Laptop-15s-du1xxx:~/kyverno-envoy-plugin$ kubectl run test -it --rm --restart=Never --image=busybox -- wget -q --output-document - echo.demo.svc.cluster.local:8080/foo

If you don't see a command prompt, try pressing enter.
warning: couldn't attach to pod/test, falling back to streaming logs: Internal error occurred: error attaching to container: failed to load task: no running task found: task b774615d16d54e33d7853d49d28f35a29fe23d9967d2f88fb10515167b1eb836 not found: not found
{
  "path": "/foo",
  "headers": {
    "host": "echo.demo.svc.cluster.local:8080",
    "user-agent": "Wget",
    "x-forwarded-proto": "http",
    "x-request-id": "07e0fa25-e3f9-4a89-aaa5-e7dfb777e344",
    "x-b3-traceid": "3d63b0fd625a274ab26667455c817009",
    "x-b3-spanid": "b26667455c817009",
    "x-b3-sampled": "0"
  },
  "method": "GET",
  "body": "",
  "fresh": false,
  "hostname": "echo.demo.svc.cluster.local",
  "ip": "::ffff:127.0.0.6",
  "ips": [],
  "protocol": "http",
  "query": {},
  "subdomains": [
    "svc",
    "demo",
    "echo"
  ],
  "xhr": false,
  "os": {
    "hostname": "echo-6847f9f85-vpqqg"
  },
  "connection": {}
}pod "test" deleted
```

Log stream -
```console
sanskar@sanskar-HP-Laptop-15s-du1xxx:~$ kubectl logs "$(kubectl get pod -l app=ext-authz -n demo -o jsonpath={.items..metadata.name})" -n demo -c ext-authz -f 
Starting HTTP server on Port 8000
Starting GRPC server on Port 9000
Header: :authority = echo.demo.svc.cluster.local:8080
Header: :scheme = http
Header: x-request-id = 07e0fa25-e3f9-4a89-aaa5-e7dfb777e344
Header: :path = /foo
Header: :method = GET
Header: x-forwarded-proto = http
Header: user-agent = Wget
Attributes: source:{address:{socket_address:{address:"10.244.0.11" port_value:50680}}} destination:{address:{socket_address:{address:"10.244.0.6" port_value:8080}}} request:{time:{seconds:1710516646 nanos:879496000} http:{id:"198740000404024245" method:"GET" headers:{key:":authority" value:"echo.demo.svc.cluster.local:8080"} headers:{key:":method" value:"GET"} headers:{key:":path" value:"/foo"} headers:{key:":scheme" value:"http"} headers:{key:"user-agent" value:"Wget"} headers:{key:"x-forwarded-proto" value:"http"} headers:{key:"x-request-id" value:"07e0fa25-e3f9-4a89-aaa5-e7dfb777e344"} path:"/foo" host:"echo.demo.svc.cluster.local:8080" scheme:"http" protocol:"HTTP/1.1"}} metadata_context:{} route_metadata_context:{}


```
