### PR TITLE
feat: add appProtocol to kyverno-auth-server service

### DIFF
--- a/charts/kyverno-authz-server/README.md
+++ b/charts/kyverno-authz-server/README.md
@@ -71,6 +71,7 @@ helm install kyverno-authz-server --namespace kyverno --create-namespace kyverno
 | service.type | string | `"ClusterIP"` | Service type. |
 | service.nodePort | string | `nil` | Service node port. Only used if `type` is `NodePort`. |
 | service.annotations | object | `{}` | Service annotations. |
+| service.appProtocol | string | `nil` | Service application protocol. Only needed in specific cases (eg: kgateway needs kubernetes.io/h2c to work properly) |
 | webhook.annotations | object | `{}` | Webhook annotations |
 | webhook.failurePolicy | string | `"Fail"` | Webhook failure policy |
 | webhook.objectSelector | string | `nil` | Webhook object selector |

--- a/charts/kyverno-authz-server/README.md
+++ b/charts/kyverno-authz-server/README.md
@@ -71,7 +71,7 @@ helm install kyverno-authz-server --namespace kyverno --create-namespace kyverno
 | service.type | string | `"ClusterIP"` | Service type. |
 | service.nodePort | string | `nil` | Service node port. Only used if `type` is `NodePort`. |
 | service.annotations | object | `{}` | Service annotations. |
-| service.appProtocol | string | `nil` | Service application protocol. Only needed in specific cases (eg: kgateway needs kubernetes.io/h2c to work properly) |
+| service.appProtocol | string | `nil` | Service application protocol. Setting app protocol is only needed in specific cases like integration with certain gateways. ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol |
 | webhook.annotations | object | `{}` | Webhook annotations |
 | webhook.failurePolicy | string | `"Fail"` | Webhook failure policy |
 | webhook.objectSelector | string | `nil` | Webhook object selector |

--- a/charts/kyverno-authz-server/templates/service.yaml
+++ b/charts/kyverno-authz-server/templates/service.yaml
@@ -15,9 +15,9 @@ spec:
   - name: grpc
     port: {{ .Values.service.port }}
     protocol: TCP
-    {{- if (not (empty .Values.service.appProtocol)) }}
-    appProtocol: {{ .Values.service.appProtocol }}
-    {{- end}}
+    {{- with .Values.service.appProtocol }}
+    appProtocol: {{ . }}
+    {{- end }}
     targetPort: grpc
     {{- if and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) }}
     nodePort: {{ .Values.service.nodePort }}

--- a/charts/kyverno-authz-server/templates/service.yaml
+++ b/charts/kyverno-authz-server/templates/service.yaml
@@ -15,6 +15,9 @@ spec:
   - name: grpc
     port: {{ .Values.service.port }}
     protocol: TCP
+    {{- if not empty .Values.service.appProtocol }}
+    appProtocol: {{ .Values.service.appProtocol }}
+    {{- end}}
     targetPort: grpc
     {{- if and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort)) }}
     nodePort: {{ .Values.service.nodePort }}

--- a/charts/kyverno-authz-server/templates/service.yaml
+++ b/charts/kyverno-authz-server/templates/service.yaml
@@ -15,7 +15,7 @@ spec:
   - name: grpc
     port: {{ .Values.service.port }}
     protocol: TCP
-    {{- if not empty .Values.service.appProtocol }}
+    {{- if (not (empty .Values.service.appProtocol)) }}
     appProtocol: {{ .Values.service.appProtocol }}
     {{- end}}
     targetPort: grpc

--- a/charts/kyverno-authz-server/values.yaml
+++ b/charts/kyverno-authz-server/values.yaml
@@ -249,7 +249,7 @@ service:
   annotations: {}
 
   # -- Service application protocol.
-  # Setting app protocol is only needed in specific cases like integration with certain gateways
+  # Setting app protocol is only needed in specific cases like integration with certain gateways.
   # ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
   appProtocol:
 

--- a/charts/kyverno-authz-server/values.yaml
+++ b/charts/kyverno-authz-server/values.yaml
@@ -248,6 +248,11 @@ service:
   # -- Service annotations.
   annotations: {}
 
+  # -- Service application protocol.
+  # Setting app protocol is only needed in specific cases like integration with certain gateways
+  # ref: https://kubernetes.io/docs/concepts/services-networking/service/#application-protocol
+  appProtocol:
+
 webhook:
 
   # -- Webhook annotations

--- a/website/docs/tutorials/kgateway/index.md
+++ b/website/docs/tutorials/kgateway/index.md
@@ -147,6 +147,7 @@ helm install kyverno-authz-server \
   --namespace kyverno --create-namespace \
   --wait \
   --repo https://kyverno.github.io/kyverno-envoy-plugin kyverno-authz-server \
+  --set service.appProtocol="kubernetes.io/h2c" \
   --set certificates.certManager.issuerRef.group=cert-manager.io \
   --set certificates.certManager.issuerRef.kind=ClusterIssuer \
   --set certificates.certManager.issuerRef.name=selfsigned-issuer


### PR DESCRIPTION
## Explanation

This PR adds support for `appProtocol` on the `kyverno-auth-server` service (that is needed by some envoy proxy implementations like in KGateway)