### PR TITLE
fix(config): Fix external-policy templating error

### DIFF
--- a/charts/kyverno-authz-server/templates/deployment.yaml
+++ b/charts/kyverno-authz-server/templates/deployment.yaml
@@ -109,6 +109,6 @@ spec:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           {{- range $.Values.externalPolicySources }}
-            {{- (printf "--external-policy-source=%s" (tpl (toYaml .) $)) | nindent 12 }}
+            {{- (printf "- --external-policy-source=%s" (tpl (toYaml .) $)) | nindent 12 }}
           {{- end }}
         {{- end }}

--- a/charts/kyverno-authz-server/templates/deployment.yaml
+++ b/charts/kyverno-authz-server/templates/deployment.yaml
@@ -109,6 +109,6 @@ spec:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           {{- range $.Values.externalPolicySources }}
-            {{- (printf "- --external-policy-source=%s" (tpl (toYaml .) $)) | nindent 12 }}
+            - {{ printf "--external-policy-source=%s" (tpl (toYaml .) $) }}
           {{- end }}
         {{- end }}

--- a/charts/kyverno-sidecar-injector/templates/deployment.yaml
+++ b/charts/kyverno-sidecar-injector/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           {{- range $.Values.externalPolicySources }}
-            {{- (printf "- --external-policy-source=%s" (tpl (toYaml .) $)) | nindent 12 }}
+            - {{ printf "--external-policy-source=%s" (tpl (toYaml .) $) }}
           {{- end }}
           volumeMounts:
             - name: certs

--- a/charts/kyverno-sidecar-injector/templates/deployment.yaml
+++ b/charts/kyverno-sidecar-injector/templates/deployment.yaml
@@ -113,7 +113,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           {{- range $.Values.externalPolicySources }}
-            {{- (printf "--external-policy-source=%s" (tpl (toYaml .) $)) | nindent 12 }}
+            {{- (printf "- --external-policy-source=%s" (tpl (toYaml .) $)) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - name: certs


### PR DESCRIPTION
## Explanation

When `.Values.externalPolicySources` is set, templating fails with error. This PR fixes the issue.