### PR TITLE
feat: Add json CEL library

### DIFF
--- a/pkg/cel/env.go
+++ b/pkg/cel/env.go
@@ -3,7 +3,9 @@ package cel
 import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/ext"
+	jsonimpl "github.com/kyverno/kyverno-envoy-plugin/pkg/cel/impl"
 	"github.com/kyverno/kyverno-envoy-plugin/pkg/cel/libs/envoy"
+	jsoncel "github.com/kyverno/kyverno-envoy-plugin/pkg/cel/libs/json"
 	"github.com/kyverno/kyverno-envoy-plugin/pkg/cel/libs/jwt"
 	"github.com/kyverno/kyverno/pkg/cel/libs/http"
 	"github.com/kyverno/kyverno/pkg/cel/libs/image"
@@ -39,6 +41,7 @@ func NewEnv() (*cel.Env, error) {
 		// register our libs
 		envoy.Lib(),
 		jwt.Lib(),
+		jsoncel.Lib(&jsonimpl.JsonImpl{}),
 		// register kyverno libs
 		image.Lib(),
 		imagedata.Lib(),

--- a/pkg/cel/impl/json.go
+++ b/pkg/cel/impl/json.go
@@ -1,0 +1,19 @@
+package impl
+
+import (
+	"encoding/json"
+
+	jsoncel "github.com/kyverno/kyverno-envoy-plugin/pkg/cel/libs/json"
+)
+
+type JsonImpl struct {
+	jsoncel.JsonImpl
+}
+
+func (j *JsonImpl) Unmarshal(content []byte) (any, error) {
+	var v any
+	if err := json.Unmarshal(content, &v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}

--- a/pkg/cel/libs/json/impl.go
+++ b/pkg/cel/libs/json/impl.go
@@ -1,0 +1,25 @@
+package json
+
+import (
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/kyverno/kyverno-envoy-plugin/pkg/cel/utils"
+)
+
+type impl struct {
+	types.Adapter
+}
+
+func (i *impl) unmarshal(json ref.Val, value ref.Val) ref.Val {
+	if json, err := utils.ConvertToNative[Json](json); err != nil {
+		return types.WrapErr(err)
+	} else if value, err := utils.ConvertToNative[string](value); err != nil {
+		return types.WrapErr(err)
+	} else {
+		if value, err := json.Unmarshal([]byte(value)); err != nil {
+			return types.WrapErr(err)
+		} else {
+			return i.NativeToValue(value)
+		}
+	}
+}

--- a/pkg/cel/libs/json/impl_test.go
+++ b/pkg/cel/libs/json/impl_test.go
@@ -1,0 +1,116 @@
+package json
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/ext"
+)
+
+type mockJson struct {
+	ret any
+	err error
+}
+
+func (m *mockJson) Unmarshal(b []byte) (any, error) {
+	return m.ret, m.err
+}
+
+func TestImplUnmarshal(t *testing.T) {
+	// Create a CEL environment with proper type registration
+	env, err := cel.NewEnv(
+		ext.NativeTypes(reflect.TypeFor[Json]()),
+	)
+	if err != nil {
+		t.Fatalf("failed to create CEL environment: %v", err)
+	}
+	adapter := env.CELTypeAdapter()
+	i := &impl{adapter}
+
+	type testCase struct {
+		name         string
+		jsonVal      any
+		valueVal     any
+		expectErr    bool
+		expectResult any
+	}
+
+	tests := []testCase{
+		{
+			name:         "success",
+			jsonVal:      Json{&mockJson{ret: map[string]any{"foo": "bar"}, err: nil}},
+			valueVal:     `{"foo":"bar"}`,
+			expectErr:    false,
+			expectResult: map[string]any{"foo": "bar"},
+		},
+		{
+			name:      "json convert error",
+			jsonVal:   "not a json struct",
+			valueVal:  "irrelevant",
+			expectErr: true,
+		},
+		{
+			name:      "value convert error",
+			jsonVal:   Json{&mockJson{ret: nil, err: nil}},
+			valueVal:  12345,
+			expectErr: true,
+		},
+		{
+			name:      "unmarshal error",
+			jsonVal:   Json{&mockJson{ret: nil, err: errors.New("unmarshal failed")}},
+			valueVal:  "bad json",
+			expectErr: true,
+		},
+		{
+			name:      "json is nil",
+			jsonVal:   nil,
+			valueVal:  `{"foo":"bar"}`,
+			expectErr: true,
+		},
+		{
+			name:      "value is nil",
+			jsonVal:   Json{&mockJson{ret: map[string]any{"foo": "bar"}, err: nil}},
+			valueVal:  nil,
+			expectErr: true,
+		},
+		{
+			name:         "value is empty string",
+			jsonVal:      Json{&mockJson{ret: map[string]any{}, err: nil}},
+			valueVal:     "",
+			expectErr:    false,
+			expectResult: map[string]any{},
+		},
+		{
+			name:         "json is empty struct",
+			jsonVal:      Json{&mockJson{ret: map[string]any{}, err: nil}},
+			valueVal:     `{"foo":"bar"}`,
+			expectErr:    false,
+			expectResult: map[string]any{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			jsonVal := adapter.NativeToValue(tc.jsonVal)
+			valueVal := adapter.NativeToValue(tc.valueVal)
+			result := i.unmarshal(jsonVal, valueVal)
+			if tc.expectErr {
+				if result.Type() != types.ErrType {
+					t.Errorf("expected error type, got %v", result.Type())
+				}
+			} else {
+				// Convert the result back to native type for comparison
+				got, err := result.ConvertToNative(reflect.TypeOf(tc.expectResult))
+				if err != nil {
+					t.Fatalf("unexpected conversion error: %v", err)
+				}
+				if !reflect.DeepEqual(got, tc.expectResult) {
+					t.Errorf("expected result %v, got %v", tc.expectResult, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cel/libs/json/lib.go
+++ b/pkg/cel/libs/json/lib.go
@@ -43,7 +43,7 @@ func (l *lib) ProgramOptions() []cel.ProgramOption {
 	}
 }
 
-func (_ *lib) extendEnv(env *cel.Env) (*cel.Env, error) {
+func (*lib) extendEnv(env *cel.Env) (*cel.Env, error) {
 	// get env type adapter
 	adapter := env.CELTypeAdapter()
 	// create implementation with adapter

--- a/pkg/cel/libs/json/lib.go
+++ b/pkg/cel/libs/json/lib.go
@@ -19,7 +19,7 @@ func Lib(json JsonImpl) cel.EnvOption {
 	})
 }
 
-func (_ *lib) LibraryName() string {
+func (*lib) LibraryName() string {
 	return "kyverno.json"
 }
 

--- a/pkg/cel/libs/json/lib.go
+++ b/pkg/cel/libs/json/lib.go
@@ -1,0 +1,64 @@
+package json
+
+import (
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/ext"
+)
+
+type lib struct {
+	json Json
+}
+
+func Lib(json JsonImpl) cel.EnvOption {
+	// create the cel lib env option
+	return cel.Lib(&lib{
+		json: Json{json},
+	})
+}
+
+func (_ *lib) LibraryName() string {
+	return "kyverno.json"
+}
+
+func (l *lib) CompileOptions() []cel.EnvOption {
+	return []cel.EnvOption{
+		cel.Variable("json", JsonType),
+		// register native types
+		ext.NativeTypes(reflect.TypeFor[Json]()),
+		// extend environment with function overloads
+		l.extendEnv,
+	}
+}
+
+func (l *lib) ProgramOptions() []cel.ProgramOption {
+	return []cel.ProgramOption{
+		cel.Globals(
+			map[string]any{
+				"json": l.json,
+			},
+		),
+	}
+}
+
+func (_ *lib) extendEnv(env *cel.Env) (*cel.Env, error) {
+	// get env type adapter
+	adapter := env.CELTypeAdapter()
+	// create implementation with adapter
+	impl := impl{adapter}
+	// build our function overloads
+	libraryDecls := map[string][]cel.FunctionOpt{
+		"Unmarshal": {
+			cel.MemberOverload("unmarshal_string_dyn", []*cel.Type{JsonType, types.DynType}, types.DynType, cel.BinaryBinding(impl.unmarshal)),
+		},
+	}
+	// create env options corresponding to our function overloads
+	options := []cel.EnvOption{}
+	for name, overloads := range libraryDecls {
+		options = append(options, cel.Function(name, overloads...))
+	}
+	// extend environment with our function overloads
+	return env.Extend(options...)
+}

--- a/pkg/cel/libs/json/types.go
+++ b/pkg/cel/libs/json/types.go
@@ -1,0 +1,15 @@
+package json
+
+import (
+	"github.com/google/cel-go/common/types"
+)
+
+var JsonType = types.NewOpaqueType("json.Json")
+
+type JsonImpl interface {
+	Unmarshal([]byte) (any, error)
+}
+
+type Json struct {
+	JsonImpl
+}

--- a/website/docs/cel-extensions/index.md
+++ b/website/docs/cel-extensions/index.md
@@ -7,6 +7,7 @@ The CEL engine used to evaluate variables and authorization rules has been exten
 - [Envoy](./envoy.md)
 - [Jwk](./jwk.md)
 - [Jwt](./jwt.md)
+- [Json](./json.md)
 
 ## Common libraries
 

--- a/website/docs/cel-extensions/json.md
+++ b/website/docs/cel-extensions/json.md
@@ -1,0 +1,22 @@
+# JSON library
+
+The JSON CEL library provides functions for parsing JSON strings into CEL values.
+
+## Functions
+
+### json.Unmarshal
+
+The `json` function parses a JSON-encoded string and returns the corresponding CEL value. This allows you to work with JSON data directly in CEL expressions.
+
+#### Signature
+
+```
+json.Unmarshal(<string> jsonString) -> Map[string][any]
+```
+
+### Example
+
+```
+# Check JSON nested value
+json.Unmarshal("{\"item1\": { \"item2\": 123 } \"}").item1.item2 == 123
+```

--- a/website/docs/cel-extensions/json.md
+++ b/website/docs/cel-extensions/json.md
@@ -11,7 +11,7 @@ The `json` function parses a JSON-encoded string and returns the corresponding C
 #### Signature
 
 ```
-json.Unmarshal(<string> jsonString) -> Map[string][any]
+json.Unmarshal(<string> jsonString) -> any
 ```
 
 ### Example


### PR DESCRIPTION
## Explanation

By default, `cel-go` doesn't provide a JSON lib and getting something from the body inside the `CheckRequest` can be very painful.

This PR adds support for a new `json` CEL library that will allow us parse a json string using `json.Unmarshal(...)`.

## Proposed Changes

Adds a `json` cel library that allows json string transformations.

```
# In a cell policy, this should be true
json.Unmarshal("{\"key\": { \"nestedKey\" : 123 }}").key.nestedKey == 123
```

### Policy example

```yaml
# Test during an MCP call that server that the requested resource is a pod
apiVersion: policies.kyverno.io/v1alpha1
kind: ValidatingPolicy
metadata:
  name: policy
spec:
  evaluation:
    mode: Envoy
  variables:
    - name: body
      expression: json.Unmarshal(object.attributes.request.http.body)
  validations:
  - expression: |
       variables.body.params.arguments.resource_type == "pods" ?
      	envoy.Allowed().Response() : envoy.Denied(403).Response()
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.

## Further Comments
