### PR TITLE
feat: Update For method signature

### DIFF
--- a/pkg/engine/policy.go
+++ b/pkg/engine/policy.go
@@ -8,5 +8,5 @@ import (
 type PolicyFunc func() (*authv3.CheckResponse, error)
 
 type CompiledPolicy interface {
-	For(*authv3.CheckRequest, dynamic.Interface) (PolicyFunc, PolicyFunc)
+	Evaluate(*authv3.CheckRequest, dynamic.Interface) (*authv3.CheckResponse, error)
 }

--- a/pkg/engine/vpol/compiler/compiler_test.go
+++ b/pkg/engine/vpol/compiler/compiler_test.go
@@ -105,10 +105,7 @@ func TestCompiler(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		allow, deny := compiled.For(test.request, nil)
-		assert.Nil(t, deny)
-		assert.NotNil(t, allow)
-		resp, err := allow()
+		resp, err := compiled.Evaluate(test.request, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, resp)
 


### PR DESCRIPTION
## Explanation

Following the cleanup of the `AuthorizationPolicy`, we don't need to have both `allow()` and `deny()` functions.